### PR TITLE
Bleeding edge travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ before_script:
 - bundle exec rake db:migrate
 script:
 - bundle exec rspec
-branches:
-  only:
-  - master
 sudo: false
 deploy:
   provider: heroku


### PR DESCRIPTION
This enables the new docker based setup on Travis for faster build feedback. Please do not change this for other services as it's still early days and they're not ready for a lot of builds yet.
