### PR TITLE
No security for api call

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,8 +3,6 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
-  before_action :authenticate, if: -> { Rails.env.production? }
-
   private
 
   def authenticate

--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -1,6 +1,8 @@
 class DeploysController < ApplicationController
   include ActionController::Live
 
+  before_action :authenticate, except: [:ping, :deploy], if: -> { Rails.env.production? }
+
   def index
     @deploys = Deploy.production.map { |d| DeployPresenter.new(d) }
   end


### PR DESCRIPTION
:no_entry_sign: Remove security for `/ping` or `POST /deploy`
