### PR TITLE
Remove csrf for api

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,4 @@
 class ApplicationController < ActionController::Base
-  # Prevent CSRF attacks by raising an exception.
-  # For APIs, you may want to use :null_session instead.
-  protect_from_forgery with: :exception
 
   private
 

--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -1,6 +1,8 @@
 class DeploysController < ApplicationController
   include ActionController::Live
 
+  protect_from_forgery with: :exception, except: [ :deploy ]
+
   before_action :authenticate, except: [:ping, :deploy], if: -> { Rails.env.production? }
 
   def index


### PR DESCRIPTION
:hocho: Remove CSRF for `POST /deploy` 

As we only ever call this with `curl -X POST https://deploylist.herokuapp.com` from the `ht production-deploy` and don't want to generate the token, we can bypass CSRF.
