### PR TITLE
[hotfix] adjust domain_user? check to use correct hash key

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -10,6 +10,6 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   private
 
   def domain_user?
-    request.env['omniauth.auth']['extra']['raw_info']['hd'] =~ Regexp.new(ENV['GOOGLE_DOMAIN'])
+    request.env['omniauth.auth']['extra']['raw_info']['email'] =~ Regexp.new(ENV['GOOGLE_DOMAIN'])
   end
 end


### PR DESCRIPTION
Adjust the `domain_user?` check to use the `email` hash key (rather than hd) for domain checking.

Our HouseTrip OAuth logins were providing this param, but other accounts were not. We’re now matching the `domain_user?` regex on the `email` param instead.
